### PR TITLE
remove dependency on scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 laspy
-scikit-learn>=0.15.0
 scipy>=0.11
 pytest
 mock


### PR DESCRIPTION
Scikit-learn is actually not used anywhere in the code, removing the dependency solves the building issue with python 3.5 on travis.