### PR TITLE
Select equal multivalues

### DIFF
--- a/laserchicken/filter.py
+++ b/laserchicken/filter.py
@@ -19,15 +19,19 @@ from laserchicken.utils import copy_point_cloud, add_metadata
 def select_equal(point_cloud, attribute, value, return_mask=False):
     """
     Return the selection of the input point cloud that contains only points with a given attribute equal to some value.
+    If a list of values is given, select the points corresponding to any of the provided values.
 
     :param point_cloud: Input point cloud.
     :param attribute: The attribute name used for selection
-    :param value: The value to compare the attribute to
+    :param value: The value(s) to compare the attribute to
     :param return_mask: If true, return the mask corresponding to the selection
     :return:
     """
     _check_valid_arguments(attribute, point_cloud)
-    mask = point_cloud[point][attribute]['data'] == value
+    # broadcast using shape of the values
+    mask = point_cloud[point][attribute]['data'] == np.array(value)[..., None]
+    if mask.ndim > 1:
+        mask = np.any(mask, axis=0)  # reduce
     if return_mask:
         return mask
     point_cloud_filtered = copy_point_cloud(point_cloud, mask)

--- a/laserchicken/filter.py
+++ b/laserchicken/filter.py
@@ -23,7 +23,8 @@ def select_equal(point_cloud, attribute, value, return_mask=False):
     :param point_cloud: Input point cloud.
     :param attribute: The attribute name used for selection
     :param value: The value to compare the attribute to
-    :return: A new point cloud containing only the selected points
+    :param return_mask: If true, return the mask corresponding to the selection
+    :return:
     """
     _check_valid_arguments(attribute, point_cloud)
     mask = point_cloud[point][attribute]['data'] == value
@@ -42,7 +43,8 @@ def select_above(point_cloud, attribute, threshold, return_mask=False):
     :param point_cloud: Input point cloud
     :param attribute: The attribute name used for selection
     :param threshold: The threshold value used for selection
-    :return: A new point cloud containing only the selected points
+    :param return_mask: If true, return the mask corresponding to the selection
+    :return:
     """
     _check_valid_arguments(attribute, point_cloud)
     mask = point_cloud[point][attribute]['data'] > threshold
@@ -61,7 +63,8 @@ def select_below(point_cloud, attribute, threshold, return_mask=False):
     :param point_cloud: Input point cloud
     :param attribute: The attribute name used for selection
     :param threshold: The threshold value used for selection
-    :return: A new point cloud containing only the selected points
+    :param return_mask: If true, return the mask corresponding to the selection
+    :return:
     """
     _check_valid_arguments(attribute, point_cloud)
     mask = point_cloud[point][attribute]['data'] < threshold

--- a/laserchicken/test_filter.py
+++ b/laserchicken/test_filter.py
@@ -49,6 +49,13 @@ class TestSelectEqual(unittest.TestCase):
         assert_equal(len(pc_out[point]['x']['data']), 2)
 
     @staticmethod
+    def test_selectEqual_multipleValues():
+        """ Correct number of results. """
+        pc_in = get_test_data()
+        pc_out = select_equal(pc_in, 'return', [1, 2])
+        assert_equal(len(pc_out[point]['x']['data']), 3)
+
+    @staticmethod
     def test_selectEqual_maskCorrect():
         """ Correct number of results. """
         pc_in = get_test_data()


### PR DESCRIPTION
@rogerkuou @meiertgrootes When trying to combine filters outside `laserchicken` using the corresponding masks I have realised that this approach has two issues: 
 - different filter combinations can in principle require different logical operations among them (e.g. filtering the attribute ‘x’ might require an ‘OR’ if we want to apply the filters x<3 and x > 5, but and ‘AND’ if we want the filters x>3 and x<5). In the context of the pipeline, setting up multiple filters in the most general way would requiring the user to specify how the different filters have to be logically combined - which seems to me an overkill. 
- I have also realised that by combining the masks coming from different filters outside laserchicken, no entry is added to the log, which is not ideal for data provenance. 

On the other hand, what we ultimately need now is to perform a `select_equal` with multiple possible values for an attributes. This could be used e.g. to select all non-ground values for `raw_classification`. I have implemented it here, it required very little change and no change in the pipeline - I think this is the way to go for now, but let me know if you think otherwise..