### PR TITLE
Remove Python 3.5 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: trusty
+dist: xenial
 sudo: false
 
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ dist: trusty
 sudo: false
 
 python:
-- "3.5"
 - "3.6"
+- "3.7"
+- "3.8"
 
 before_install:
 - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## Changed:
+- drop python 3.5 due to problematic lazperf dependency, includes CI on python 3.7 and 3.8 
 
 ## 0.4.2 - 2020-09-18
 ## Added:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Toolkit for handling point clouds created using airborne laser scanning (ALS). F
 
 # Installation
 Prerequisites:
-- Python 3.5 or higher (3.6 is recommended)
+- Python 3.6 or higher
 - pip
 ```
 pip install laserchicken


### PR DESCRIPTION
Due to failing installation of `lazperf` in python 3.5, CI is failing. Considering that `pip` support for python 3.5 will be dropped soon, we can remove it and add travis runs for python 3.7 and 3.8.   