### PR TITLE
Remove codacy badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Please cite the software if you are using it in your scientific publication.
 </p>
 
 [![Build Status](https://github.com/eEcoLiDAR/laserchicken/workflows/Build/badge.svg)](https://github.com/eEcoLiDAR/laserchicken/actions)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/6e3836750fe14f34ba85e26956e8ef10)](https://www.codacy.com/app/c-meijer/eEcoLiDAR?utm_source=www.github.com&amp;utm_medium=referral&amp;utm_content=eEcoLiDAR/eEcoLiDAR&amp;utm_campaign=Badge_Grade)
 [![Coverage Status](https://coveralls.io/repos/github/eEcoLiDAR/laserchicken/badge.svg)](https://coveralls.io/github/eEcoLiDAR/laserchicken)
 [![DOI](https://zenodo.org/badge/95649056.svg)](https://zenodo.org/badge/latestdoi/95649056)
 [![Documentation Status](https://readthedocs.org/projects/laserchicken/badge/?version=latest)](https://laserchicken.readthedocs.io/en/latest/)


### PR DESCRIPTION
The badge was broken as well as the link. Maybe Codacy somehow stopped supporting our project? Not important enough to find out.