### PR TITLE
Enable handling of sub-field attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
+- laserchicken can now handle sub-field attributes derived from composite dimensions (e.g.
+  "raw_classification" and "bit_fields")
+
 ## Changed
 
 - move to stable Python versions (3.9, 3.10, 3.11)

--- a/laserchicken/io/las_handler.py
+++ b/laserchicken/io/las_handler.py
@@ -28,9 +28,17 @@ class LASHandler(IOHandler):
         :return: point cloud data structure
         """
         file = laspy.read(self.path)
-        dtype = file.header.point_format.dtype()
+        point_format = file.point_format
+        # dimension_names gives access to all the standard and custom
+        # dimensions, including derived sub-fields such as e.g.
+        # "classification", "synthetic", "return_number", and
+        # "number_of_returns")
+        dim_names = list(point_format.dimension_names)
+        # dtype gives access to "raw" dimensions packed as composed fields
+        # (e.g. "raw_classification" and "bit_fields")
+        raw_dim_names = list(point_format.dtype().fields.keys())
         attributes_available = [el if el not in ['X', 'Y', 'Z'] else el.lower()
-                                for el in dtype.fields.keys()]
+                                for el in set(dim_names + raw_dim_names)]
 
         attributes = select_valid_attributes(attributes_available, attributes)
 


### PR DESCRIPTION
In order to address #190, this PR allows laserchicken to handle sub-fields dimensions that are derived from "composite" dimensions such as "raw_classification" and "bit_fields". Laserchicken should now be able to parse attributes such as "number_of_returns" and "return_number":

```python
from laserchicken.io.load import load
pc = load("testdata/AHN3.laz", attributes = ["number_of_returns", "return_number"])
pc["vertex"]["number_of_returns"]
# {'type': 'uint8', 'data': array([1, 1, 1, ..., 1, 1, 1], dtype=uint8)}
``` 